### PR TITLE
feat(cli): Display real system information in info command

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ qyv run mi-aplicacion.qyv
 
 ## 📖 Documentación
 
-- **[Estructura del Proyecto](docs/ESTRUTURA.md)** - Arquitectura y organización
+- **[Estructura del Proyecto](docs/ESTRUCTURA.md)** - Arquitectura y organización
 - **[CLI y Shell](docs/CLI.md)** - Guía completa de comandos
 - **[Runtime WASM](docs/RUNTIME.md)** - Motor de ejecución
 - **[Manifiestos .qyv](docs/MANIFESTOS.md)** - Configuración de módulos

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "cli"
 version = "0.1.0"
 edition = "2024"
+license = "MIT OR Apache-2.0"
 
 [dependencies]
 clap = { workspace = true }
@@ -19,6 +20,7 @@ reqwest = { workspace = true }
 ring = { workspace = true }
 time = { workspace = true }
 strip-ansi-escapes = { workspace = true }
+sysinfo = { version = "0.35.2", features = ["multithread"] }
 
 [dev-dependencies]
 assert_cmd = { workspace = true }

--- a/cli/src/shell/commands/info.rs
+++ b/cli/src/shell/commands/info.rs
@@ -1,50 +1,31 @@
-// # VolleyDevByMaubry [21/∞] "La información revela los secretos del entorno con un solo vistazo."
+// # VolleyDevByMaubry [21/∞] "La información revela el estado real del sistema y entorno."
 use crate::shell::context::ShellContext;
 use crate::shell::ui::{print_info_box, print_separator};
+use crate::shell::system::SystemInfo;
 use std::error::Error;
 
 pub fn execute_info(context: &ShellContext) -> Result<(), Box<dyn Error>> {
     print_separator();
+    let sysinfo = SystemInfo::gather();
     print_info_box(
         "Qyvol Runtime v0.1.0",
         &[
             ("Directorio", &context.current_dir.to_string_lossy()),
             ("Tipo de proyecto", context.get_project_name()),
-            (
-                "Módulos .qyv",
-                &context
-                    .project_stats
-                    .as_ref()
-                    .map_or("0".to_string(), |s| s.qyv_files.to_string()),
-            ),
-            (
-                "Módulos .wasm",
-                &context
-                    .project_stats
-                    .as_ref()
-                    .map_or("0".to_string(), |s| s.wasm_files.to_string()),
-            ),
-            (
-                "Proyectos Rust",
-                &context
-                    .project_stats
-                    .as_ref()
-                    .map_or("0".to_string(), |s| s.rust_projects.to_string()),
-            ),
-            (
-                "Proyectos Go",
-                &context
-                    .project_stats
-                    .as_ref()
-                    .map_or("0".to_string(), |s| s.go_projects.to_string()),
-            ),
-            (
-                "Tamaño total",
-                &context.project_stats.as_ref().map_or("0B".to_string(), |s| s.format_size()),
-            ),
-            ("Memoria WASM", "12.4MB disponible"),
-            ("Red", "Habilitada"),
-            ("FS Backend", "diskfs"),
+            ("Sistema", &sysinfo.system_name),
+            ("Kernel", &sysinfo.kernel_version),
+            ("Versión OS", &sysinfo.os_version),
+            ("Host", &sysinfo.host_name),
+            ("Memoria total", &format!("{} MB", sysinfo.total_memory / 1024)),
+            ("Memoria usada", &format!("{} MB", sysinfo.used_memory / 1024)),
+            ("CPU", &format!("{} ({} núcleos, {:.1}% uso)", sysinfo.cpu_brand, sysinfo.cpu_cores, sysinfo.cpu_usage)),
+            ("Discos", &sysinfo.disks.join(", ").to_string()),
+            ("Redes", &sysinfo.networks.join(", ").to_string()),
+            ("Módulos .qyv", &context.project_stats.as_ref().map_or("0".to_string(), |s| s.qyv_files.to_string())),
+            ("Módulos .wasm", &context.project_stats.as_ref().map_or("0".to_string(), |s| s.wasm_files.to_string())),
+            ("Proyectos Rust", &context.project_stats.as_ref().map_or("0".to_string(), |s| s.rust_projects.to_string())),
+            ("Proyectos Go", &context.project_stats.as_ref().map_or("0".to_string(), |s| s.go_projects.to_string())),
+            ("Tamaño total", &context.project_stats.as_ref().map_or("0B".to_string(), |s| s.format_size())),
         ],
     );
     print_separator();

--- a/cli/src/shell/commands/mod.rs
+++ b/cli/src/shell/commands/mod.rs
@@ -9,6 +9,7 @@ pub mod info;
 pub mod nav;
 pub mod scan;
 pub mod template;
+pub mod trait_command;
 
 pub struct CommandHandler;
 

--- a/cli/src/shell/commands/trait_command.rs
+++ b/cli/src/shell/commands/trait_command.rs
@@ -1,0 +1,8 @@
+// # VolleyDevByMaubry [37/∞] "Un comando es una pieza modular, lista para ser extendida."
+#[allow(dead_code)]
+pub trait Command {
+    fn name(&self) -> &'static str;
+    fn aliases(&self) -> &[&'static str] { &[] }
+    fn description(&self) -> &'static str;
+    fn execute(&self, args: &[&str], context: &mut crate::shell::context::ShellContext) -> Result<(), Box<dyn std::error::Error>>;
+} 

--- a/cli/src/shell/mod.rs
+++ b/cli/src/shell/mod.rs
@@ -4,6 +4,8 @@ pub mod completion;
 pub mod context;
 pub mod prompt;
 pub mod ui;
+pub mod registry;
+pub mod system;
 
 use crate::shell::commands::CommandHandler;
 use crate::shell::completion::QyvolCompleter;
@@ -17,6 +19,10 @@ use rustyline::{
 };
 use std::borrow::Cow;
 use std::error::Error;
+
+pub use crate::shell::commands::trait_command::Command;
+#[allow(unused_imports)]
+pub use crate::shell::registry::CommandRegistry;
 
 struct QyvolHelper {
     completer: QyvolCompleter,

--- a/cli/src/shell/registry.rs
+++ b/cli/src/shell/registry.rs
@@ -1,0 +1,37 @@
+// # VolleyDevByMaubry [38/∞] "El registro de comandos es el corazón extensible de la shell."
+use std::collections::HashMap;
+use crate::shell::commands::trait_command::Command;
+
+#[allow(dead_code)]
+pub struct CommandRegistry {
+    commands: HashMap<String, Box<dyn Command>>,
+}
+
+impl Default for CommandRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[allow(dead_code)]
+impl CommandRegistry {
+    pub fn new() -> Self {
+        CommandRegistry { commands: HashMap::new() }
+    }
+
+    pub fn register(&mut self, command: Box<dyn Command>) {
+        self.commands.insert(command.name().to_string(), command);
+    }
+
+    pub fn get(&self, name: &str) -> Option<&dyn Command> {
+        self.commands.get(name).map(|b| b.as_ref())
+    }
+
+    pub fn execute(&self, name: &str, args: &[&str], context: &mut crate::shell::context::ShellContext) -> Result<(), Box<dyn std::error::Error>> {
+        if let Some(cmd) = self.get(name) {
+            cmd.execute(args, context)
+        } else {
+            Err(format!("Comando desconocido: {}", name).into())
+        }
+    }
+} 

--- a/cli/src/shell/system.rs
+++ b/cli/src/shell/system.rs
@@ -1,0 +1,60 @@
+// # VolleyDevByMaubry [39/∞] "El sistema revela su estado real, sin máscaras."
+use sysinfo::{System, Disks, Networks};
+
+pub struct SystemInfo {
+    pub total_memory: u64,
+    pub used_memory: u64,
+    pub cpu_brand: String,
+    pub cpu_cores: usize,
+    pub cpu_usage: f32,
+    pub system_name: String,
+    pub kernel_version: String,
+    pub os_version: String,
+    pub host_name: String,
+    pub disks: Vec<String>,
+    pub networks: Vec<String>,
+}
+
+impl SystemInfo {
+    pub fn gather() -> Self {
+        let mut sys = System::new_all();
+        sys.refresh_all();
+
+        let total_memory = sys.total_memory();
+        let used_memory = sys.used_memory();
+        let cpu_brand = sys.cpus().first().map(|c| c.brand().to_string()).unwrap_or_default();
+        let cpu_cores = sys.cpus().len();
+        let cpu_usage = if cpu_cores > 0 {
+            sys.cpus().iter().map(|c| c.cpu_usage()).sum::<f32>() / cpu_cores as f32
+        } else {
+            0.0
+        };
+        let system_name = System::name().unwrap_or_default();
+        let kernel_version = System::kernel_version().unwrap_or_default();
+        let os_version = System::os_version().unwrap_or_default();
+        let host_name = System::host_name().unwrap_or_default();
+
+        let disks = Disks::new_with_refreshed_list()
+            .iter()
+            .map(|d| d.name().to_string_lossy().to_string())
+            .collect();
+        let networks = Networks::new_with_refreshed_list()
+            .iter()
+            .map(|(n, _)| n.clone())
+            .collect();
+
+        SystemInfo {
+            total_memory,
+            used_memory,
+            cpu_brand,
+            cpu_cores,
+            cpu_usage,
+            system_name,
+            kernel_version,
+            os_version,
+            host_name,
+            disks,
+            networks,
+        }
+    }
+} 

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "common"
 version = "0.1.0"
 edition = "2024"
+license = "MIT"
 
 [dependencies]
 serde = { workspace = true }

--- a/index.html
+++ b/index.html
@@ -1,0 +1,168 @@
+<!DOCTYPE html><html lang="en"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1.0"><meta name="generator" content="rustdoc"><meta name="description" content="sysinfo  "><title>sysinfo - Rust</title><script>if(window.location.protocol!=="file:")document.head.insertAdjacentHTML("beforeend","SourceSerif4-Regular-6b053e98.ttf.woff2,FiraSans-Italic-81dc35de.woff2,FiraSans-Regular-0fe48ade.woff2,FiraSans-MediumItalic-ccf7e434.woff2,FiraSans-Medium-e1aa3f0a.woff2,SourceCodePro-Regular-8badfe75.ttf.woff2,SourceCodePro-Semibold-aa29a496.ttf.woff2".split(",").map(f=>`<link rel="preload" as="font" type="font/woff2" crossorigin href="../static.files/${f}">`).join(""))</script><link rel="stylesheet" href="../static.files/normalize-9960930a.css"><link rel="stylesheet" href="../static.files/rustdoc-916cea96.css"><meta name="rustdoc-vars" data-root-path="../" data-static-root-path="../static.files/" data-current-crate="sysinfo" data-themes="" data-resource-suffix="" data-rustdoc-version="1.87.0 (17067e9ac 2025-05-09)" data-channel="1.87.0" data-search-js="search-e7298875.js" data-settings-js="settings-d72f25bb.js" ><script src="../static.files/storage-82c7156e.js"></script><script defer src="../crates.js"></script><script defer src="../static.files/main-fb8c74a8.js"></script><noscript><link rel="stylesheet" href="../static.files/noscript-893ab5e7.css"></noscript><link rel="alternate icon" type="image/png" href="../static.files/favicon-32x32-6580c154.png"><link rel="icon" type="image/svg+xml" href="../static.files/favicon-044be391.svg"></head><body class="rustdoc mod crate"><!--[if lte IE 11]><div class="warning">This old browser is unsupported and will most likely display funky things.</div><![endif]--><nav class="mobile-topbar"><button class="sidebar-menu-toggle" title="show sidebar"></button></nav><nav class="sidebar"><div class="sidebar-crate"><h2><a href="../sysinfo/index.html">sysinfo</a><span class="version">0.35.2</span></h2></div><div class="sidebar-elems"><ul class="block"><li><a id="all-types" href="all.html">All Items</a></li></ul><section id="rustdoc-toc"><h3><a href="#">Sections</a></h3><ul class="block top-toc"><li><a href="#sysinfo--" title="sysinfo  ">sysinfo  </a><ul><li><a href="#supported-oses" title="Supported OSes">Supported OSes</a></li><li><a href="#usage" title="Usage">Usage</a></li><li><a href="#donations" title="Donations">Donations</a></li></ul></li></ul><h3><a href="#structs">Crate Items</a></h3><ul class="block"><li><a href="#structs" title="Structs">Structs</a></li><li><a href="#enums" title="Enums">Enums</a></li><li><a href="#constants" title="Constants">Constants</a></li><li><a href="#functions" title="Functions">Functions</a></li></ul></section><div id="rustdoc-modnav"></div></div></nav><div class="sidebar-resizer"></div><main><div class="width-limiter"><rustdoc-search></rustdoc-search><section id="main-content" class="content"><div class="main-heading"><h1>Crate <span>sysinfo</span><button id="copy-path" title="Copy item path to clipboard">Copy item path</button></h1><rustdoc-toolbar></rustdoc-toolbar><span class="sub-heading"><a class="src" href="../src/sysinfo/lib.rs.html#3-352">Source</a> </span></div><details class="toggle top-doc" open><summary class="hideme"><span>Expand description</span></summary><div class="docblock"><h2 id="sysinfo--"><a class="doc-anchor" href="#sysinfo--">§</a>sysinfo <a href="https://crates.io/crates/sysinfo"><img src="https://img.shields.io/crates/v/sysinfo.svg" alt="" /></a> <a href="https://docs.rs/sysinfo/"><img src="https://img.shields.io/badge/rust-documentation-blue.svg" alt="" /></a></h2>
+<p><code>sysinfo</code> is a crate used to get a system’s information.</p>
+<h3 id="supported-oses"><a class="doc-anchor" href="#supported-oses">§</a>Supported OSes</h3>
+<p>It currently supports the following OSes (alphabetically sorted):</p>
+<ul>
+<li>Android</li>
+<li>FreeBSD</li>
+<li>iOS</li>
+<li>Linux</li>
+<li>macOS</li>
+<li>Raspberry Pi</li>
+<li>Windows</li>
+</ul>
+<p>You can still use <code>sysinfo</code> on non-supported OSes, it’ll simply do nothing and always return
+empty values. You can check in your program directly if an OS is supported by checking the
+<a href="constant.IS_SUPPORTED_SYSTEM.html" title="constant sysinfo::IS_SUPPORTED_SYSTEM"><code>IS_SUPPORTED_SYSTEM</code></a> constant.</p>
+<p>The minimum-supported version of <code>rustc</code> is <strong>1.75</strong>.</p>
+<h3 id="usage"><a class="doc-anchor" href="#usage">§</a>Usage</h3>
+<p>If you want to migrate from an older version, don’t hesitate to take a look at the
+<a href="https://github.com/GuillaumeGomez/sysinfo/blob/master/CHANGELOG.md">CHANGELOG</a> and at the
+<a href="https://github.com/GuillaumeGomez/sysinfo/blob/master/migration_guide.md">migration guide</a>.</p>
+<p>⚠️ Before any attempt to read the different structs’ information, you need to update them to
+get up-to-date information because for most of them, it works on diff between the current value
+and the old one.</p>
+<p>Which is why, it’s much better to keep the same instance of <a href="struct.System.html" title="struct sysinfo::System"><code>System</code></a> around instead of
+recreating it multiple times.</p>
+<p>You have an example into the <code>examples</code> folder. You can run it with <code>cargo run --example simple</code>.</p>
+<p>Otherwise, here is a little code sample:</p>
+
+<div class="example-wrap"><pre class="rust rust-example-rendered"><code><span class="kw">use </span>sysinfo::{
+    Components, Disks, Networks, System,
+};
+
+<span class="comment">// Please note that we use "new_all" to ensure that all lists of
+// CPUs and processes are filled!
+</span><span class="kw">let </span><span class="kw-2">mut </span>sys = System::new_all();
+
+<span class="comment">// First we update all information of our `System` struct.
+</span>sys.refresh_all();
+
+<span class="macro">println!</span>(<span class="string">"=&gt; system:"</span>);
+<span class="comment">// RAM and swap information:
+</span><span class="macro">println!</span>(<span class="string">"total memory: {} bytes"</span>, sys.total_memory());
+<span class="macro">println!</span>(<span class="string">"used memory : {} bytes"</span>, sys.used_memory());
+<span class="macro">println!</span>(<span class="string">"total swap  : {} bytes"</span>, sys.total_swap());
+<span class="macro">println!</span>(<span class="string">"used swap   : {} bytes"</span>, sys.used_swap());
+
+<span class="comment">// Display system information:
+</span><span class="macro">println!</span>(<span class="string">"System name:             {:?}"</span>, System::name());
+<span class="macro">println!</span>(<span class="string">"System kernel version:   {:?}"</span>, System::kernel_version());
+<span class="macro">println!</span>(<span class="string">"System OS version:       {:?}"</span>, System::os_version());
+<span class="macro">println!</span>(<span class="string">"System host name:        {:?}"</span>, System::host_name());
+
+<span class="comment">// Number of CPUs:
+</span><span class="macro">println!</span>(<span class="string">"NB CPUs: {}"</span>, sys.cpus().len());
+
+<span class="comment">// Display processes ID, name and disk usage:
+</span><span class="kw">for </span>(pid, process) <span class="kw">in </span>sys.processes() {
+    <span class="macro">println!</span>(<span class="string">"[{pid}] {:?} {:?}"</span>, process.name(), process.disk_usage());
+}
+
+<span class="comment">// We display all disks' information:
+</span><span class="macro">println!</span>(<span class="string">"=&gt; disks:"</span>);
+<span class="kw">let </span>disks = Disks::new_with_refreshed_list();
+<span class="kw">for </span>disk <span class="kw">in </span><span class="kw-2">&amp;</span>disks {
+    <span class="macro">println!</span>(<span class="string">"{disk:?}"</span>);
+}
+
+<span class="comment">// Network interfaces name, total data received and total data transmitted:
+</span><span class="kw">let </span>networks = Networks::new_with_refreshed_list();
+<span class="macro">println!</span>(<span class="string">"=&gt; networks:"</span>);
+<span class="kw">for </span>(interface_name, data) <span class="kw">in </span><span class="kw-2">&amp;</span>networks {
+    <span class="macro">println!</span>(
+        <span class="string">"{interface_name}: {} B (down) / {} B (up)"</span>,
+        data.total_received(),
+        data.total_transmitted(),
+    );
+    <span class="comment">// If you want the amount of data received/transmitted since last call
+    // to `Networks::refresh`, use `received`/`transmitted`.
+</span>}
+
+<span class="comment">// Components temperature:
+</span><span class="kw">let </span>components = Components::new_with_refreshed_list();
+<span class="macro">println!</span>(<span class="string">"=&gt; components:"</span>);
+<span class="kw">for </span>component <span class="kw">in </span><span class="kw-2">&amp;</span>components {
+    <span class="macro">println!</span>(<span class="string">"{component:?}"</span>);
+}</code></pre></div>
+<p>Please remember that to have some up-to-date information, you need to call the equivalent
+<code>refresh</code> method. For example, for the CPU usage:</p>
+
+<div class="example-wrap"><pre class="rust rust-example-rendered"><code><span class="kw">use </span>sysinfo::System;
+
+<span class="kw">let </span><span class="kw-2">mut </span>sys = System::new();
+
+<span class="kw">loop </span>{
+    sys.refresh_cpu_usage(); <span class="comment">// Refreshing CPU usage.
+    </span><span class="kw">for </span>cpu <span class="kw">in </span>sys.cpus() {
+        <span class="macro">print!</span>(<span class="string">"{}% "</span>, cpu.cpu_usage());
+    }
+    <span class="comment">// Sleeping to let time for the system to run for long
+    // enough to have useful information.
+    </span>std::thread::sleep(sysinfo::MINIMUM_CPU_UPDATE_INTERVAL);
+}</code></pre></div>
+<p>By default, <code>sysinfo</code> uses multiple threads. However, this can increase the memory usage on some
+platforms (macOS for example). The behavior can be disabled by setting <code>default-features = false</code>
+in <code>Cargo.toml</code> (which disables the <code>multithread</code> cargo feature).</p>
+<h4 id="good-practice--performance-tips"><a class="doc-anchor" href="#good-practice--performance-tips">§</a>Good practice / Performance tips</h4>
+<p>Most of the time, you don’t want all information provided by <code>sysinfo</code> but just a subset of it.
+In this case, it’s recommended to use <code>refresh_specifics(...)</code> methods with only what you need
+to have much better performance.</p>
+<p>Another issue frequently encountered: unless you know what you’re doing, it’s almost all the
+time better to instantiate the <code>System</code> struct once and use this one instance through your
+program. The reason is because a lot of information needs a previous measure to be computed
+(the CPU usage for example). Another example why it’s much better: in case you want to list
+all running processes, <code>sysinfo</code> needs to allocate all memory for the <code>Process</code> struct list,
+which takes quite some time on the first run.</p>
+<p>If your program needs to use a lot of file descriptors, you’d better use:</p>
+
+<div class="example-wrap"><pre class="rust rust-example-rendered"><code>sysinfo::set_open_files_limit(<span class="number">0</span>);</code></pre></div>
+<p>as <code>sysinfo</code> keeps a number of file descriptors open to have better performance on some
+targets when refreshing processes.</p>
+<h4 id="running-on-raspberry-pi"><a class="doc-anchor" href="#running-on-raspberry-pi">§</a>Running on Raspberry Pi</h4>
+<p>It’ll be difficult to build on Raspberry Pi. A good way-around is to cross-build, then send the
+executable to your Raspberry Pi.</p>
+<p>First install the arm toolchain, for example on Ubuntu:</p>
+<div class="example-wrap"><pre class="language-bash"><code>&gt; sudo apt-get install gcc-multilib-arm-linux-gnueabihf</code></pre></div>
+<p>Then configure cargo to use the corresponding toolchain:</p>
+<div class="example-wrap"><pre class="language-bash"><code>cat &lt;&lt; EOF &gt; ~/.cargo/config
+[target.armv7-unknown-linux-gnueabihf]
+linker = &quot;arm-linux-gnueabihf-gcc&quot;
+EOF</code></pre></div>
+<p>Finally, cross compile:</p>
+<div class="example-wrap"><pre class="language-bash"><code>rustup target add armv7-unknown-linux-gnueabihf
+cargo build --target=armv7-unknown-linux-gnueabihf</code></pre></div><h4 id="linux-on-docker--windows-subsystem-for-linux-wsl"><a class="doc-anchor" href="#linux-on-docker--windows-subsystem-for-linux-wsl">§</a>Linux on Docker &amp; Windows Subsystem for Linux (WSL)</h4>
+<p>Virtual Linux systems, such as those run through Docker and Windows Subsystem for Linux (WSL), do
+not receive host hardware information via <code>/sys/class/hwmon</code> or <code>/sys/class/thermal</code>. As such,
+querying for components may return no results (or unexpected results) when using this library on
+virtual systems.</p>
+<h4 id="use-in-binaries-running-inside-the-macos-or-ios-sandboxstores"><a class="doc-anchor" href="#use-in-binaries-running-inside-the-macos-or-ios-sandboxstores">§</a>Use in binaries running inside the macOS or iOS Sandbox/stores</h4>
+<p>Apple has restrictions as to which APIs can be linked into binaries that are distributed through the app store.
+By default, <code>sysinfo</code> is not compatible with these restrictions. You can use the <code>apple-app-store</code>
+feature flag to disable the Apple prohibited features. This also enables the <code>apple-sandbox</code> feature.
+In the case of applications using the sandbox outside of the app store, the <code>apple-sandbox</code> feature
+can be used alone to avoid causing policy violations at runtime.</p>
+<h4 id="how-it-works"><a class="doc-anchor" href="#how-it-works">§</a>How it works</h4>
+<p>I wrote a blog post you can find <a href="https://blog.guillaume-gomez.fr/articles/2021-09-06+sysinfo%3A+how+to+extract+systems%27+information">here</a> which explains how <code>sysinfo</code> extracts information
+on the different systems.</p>
+<h4 id="running-tests"><a class="doc-anchor" href="#running-tests">§</a>Running tests</h4>
+<p>Because we’re looking at system information, some tests have a better chance to succeed when there is
+a limited number of parallel running tests. To ensure they all pass, use:</p>
+<div class="example-wrap"><pre class="language-bash"><code>cargo test -- --test-threads=1</code></pre></div><h4 id="c-interface"><a class="doc-anchor" href="#c-interface">§</a>C interface</h4>
+<p>It’s possible to use this crate directly from C. Take a look at the <code>Makefile</code> and at the
+<code>examples/simple.c</code> file.</p>
+<p>To build the C example, just run:</p>
+<div class="example-wrap"><pre class="language-bash"><code>&gt; make
+&gt; ./simple
+# If needed:
+&gt; LD_LIBRARY_PATH=target/debug/ ./simple</code></pre></div><h4 id="benchmarks"><a class="doc-anchor" href="#benchmarks">§</a>Benchmarks</h4>
+<p>You can run the benchmarks locally with rust <strong>nightly</strong> by doing:</p>
+<div class="example-wrap"><pre class="language-bash"><code>&gt; cargo bench</code></pre></div><h3 id="donations"><a class="doc-anchor" href="#donations">§</a>Donations</h3>
+<p>If you appreciate my work and want to support me, you can do it with
+<a href="https://github.com/sponsors/GuillaumeGomez">github sponsors</a> or with
+<a href="https://www.patreon.com/GuillaumeGomez">patreon</a>.</p>
+</div></details><h2 id="structs" class="section-header">Structs<a href="#structs" class="anchor">§</a></h2><dl class="item-table"><dt><a class="struct" href="struct.CGroupLimits.html" title="struct sysinfo::CGroupLimits">CGroup<wbr>Limits</a></dt><dd>Contains memory limits for the current process.</dd><dt><a class="struct" href="struct.Component.html" title="struct sysinfo::Component">Component</a></dt><dd>Getting a component temperature information.</dd><dt><a class="struct" href="struct.Components.html" title="struct sysinfo::Components">Components</a></dt><dd>Interacting with components.</dd><dt><a class="struct" href="struct.Cpu.html" title="struct sysinfo::Cpu">Cpu</a></dt><dd>Contains all the methods of the <a href="struct.Cpu.html" title="struct sysinfo::Cpu"><code>Cpu</code></a> struct.</dd><dt><a class="struct" href="struct.CpuRefreshKind.html" title="struct sysinfo::CpuRefreshKind">CpuRefresh<wbr>Kind</a></dt><dd>Used to determine what you want to refresh specifically on the <a href="struct.Cpu.html" title="struct sysinfo::Cpu"><code>Cpu</code></a> type.</dd><dt><a class="struct" href="struct.Disk.html" title="struct sysinfo::Disk">Disk</a></dt><dd>Struct containing a disk information.</dd><dt><a class="struct" href="struct.DiskRefreshKind.html" title="struct sysinfo::DiskRefreshKind">Disk<wbr>Refresh<wbr>Kind</a></dt><dd>Used to determine what you want to refresh specifically on the <a href="struct.Disk.html" title="struct sysinfo::Disk"><code>Disk</code></a> type.</dd><dt><a class="struct" href="struct.DiskUsage.html" title="struct sysinfo::DiskUsage">Disk<wbr>Usage</a></dt><dd>Type containing read and written bytes.</dd><dt><a class="struct" href="struct.Disks.html" title="struct sysinfo::Disks">Disks</a></dt><dd>Disks interface.</dd><dt><a class="struct" href="struct.Gid.html" title="struct sysinfo::Gid">Gid</a></dt><dd>A group id wrapping a platform specific type.</dd><dt><a class="struct" href="struct.Group.html" title="struct sysinfo::Group">Group</a></dt><dd>Type containing group information.</dd><dt><a class="struct" href="struct.Groups.html" title="struct sysinfo::Groups">Groups</a></dt><dd>Interacting with groups.</dd><dt><a class="struct" href="struct.IpNetwork.html" title="struct sysinfo::IpNetwork">IpNetwork</a></dt><dd>IP networks address for network interface.</dd><dt><a class="struct" href="struct.LoadAvg.html" title="struct sysinfo::LoadAvg">LoadAvg</a></dt><dd>A struct representing system load average value.</dd><dt><a class="struct" href="struct.MacAddr.html" title="struct sysinfo::MacAddr">MacAddr</a></dt><dd>MAC address for network interface.</dd><dt><a class="struct" href="struct.MemoryRefreshKind.html" title="struct sysinfo::MemoryRefreshKind">Memory<wbr>Refresh<wbr>Kind</a></dt><dd>Used to determine which memory you want to refresh specifically.</dd><dt><a class="struct" href="struct.NetworkData.html" title="struct sysinfo::NetworkData">Network<wbr>Data</a></dt><dd>Getting volume of received and transmitted data.</dd><dt><a class="struct" href="struct.Networks.html" title="struct sysinfo::Networks">Networks</a></dt><dd>Interacting with network interfaces.</dd><dt><a class="struct" href="struct.Pid.html" title="struct sysinfo::Pid">Pid</a></dt><dd>Process ID.</dd><dt><a class="struct" href="struct.Process.html" title="struct sysinfo::Process">Process</a></dt><dd>Struct containing information of a process.</dd><dt><a class="struct" href="struct.ProcessRefreshKind.html" title="struct sysinfo::ProcessRefreshKind">Process<wbr>Refresh<wbr>Kind</a></dt><dd>Used to determine what you want to refresh specifically on the <a href="struct.Process.html" title="struct sysinfo::Process"><code>Process</code></a> type.</dd><dt><a class="struct" href="struct.RefreshKind.html" title="struct sysinfo::RefreshKind">Refresh<wbr>Kind</a></dt><dd>Used to determine what you want to refresh specifically on the <a href="struct.System.html" title="struct sysinfo::System"><code>System</code></a> type.</dd><dt><a class="struct" href="struct.System.html" title="struct sysinfo::System">System</a></dt><dd>Structs containing system’s information such as processes, memory and CPU.</dd><dt><a class="struct" href="struct.Uid.html" title="struct sysinfo::Uid">Uid</a></dt><dd>A user id wrapping a platform specific type.</dd><dt><a class="struct" href="struct.User.html" title="struct sysinfo::User">User</a></dt><dd>Type containing user information.</dd><dt><a class="struct" href="struct.Users.html" title="struct sysinfo::Users">Users</a></dt><dd>Interacting with users.</dd></dl><h2 id="enums" class="section-header">Enums<a href="#enums" class="anchor">§</a></h2><dl class="item-table"><dt><a class="enum" href="enum.DiskKind.html" title="enum sysinfo::DiskKind">Disk<wbr>Kind</a></dt><dd>Enum containing the different supported kinds of disks.</dd><dt><a class="enum" href="enum.IpNetworkFromStrError.html" title="enum sysinfo::IpNetworkFromStrError">IpNetwork<wbr>From<wbr>StrError</a></dt><dd>Error type returned from <code>MacAddr::from_str</code> implementation.</dd><dt><a class="enum" href="enum.KillError.html" title="enum sysinfo::KillError">Kill<wbr>Error</a></dt><dd>Enum describing possible <a href="struct.Process.html#method.kill_and_wait" title="method sysinfo::Process::kill_and_wait"><code>Process::kill_and_wait</code></a> errors.</dd><dt><a class="enum" href="enum.MacAddrFromStrError.html" title="enum sysinfo::MacAddrFromStrError">MacAddr<wbr>From<wbr>StrError</a></dt><dd>Error type returned from <code>MacAddr::from_str</code> implementation.</dd><dt><a class="enum" href="enum.ProcessStatus.html" title="enum sysinfo::ProcessStatus">Process<wbr>Status</a></dt><dd>Enum describing the different status of a process.</dd><dt><a class="enum" href="enum.ProcessesToUpdate.html" title="enum sysinfo::ProcessesToUpdate">Processes<wbr>ToUpdate</a></dt><dd>This enum allows you to specify if you want all processes to be updated or just
+some of them.</dd><dt><a class="enum" href="enum.Signal.html" title="enum sysinfo::Signal">Signal</a></dt><dd>An enum representing signals on UNIX-like systems.</dd><dt><a class="enum" href="enum.ThreadKind.html" title="enum sysinfo::ThreadKind">Thread<wbr>Kind</a></dt><dd>Enum describing the different kind of threads.</dd><dt><a class="enum" href="enum.UpdateKind.html" title="enum sysinfo::UpdateKind">Update<wbr>Kind</a></dt><dd>This enum allows you to specify when you want the related information to be updated.</dd></dl><h2 id="constants" class="section-header">Constants<a href="#constants" class="anchor">§</a></h2><dl class="item-table"><dt><a class="constant" href="constant.IS_SUPPORTED_SYSTEM.html" title="constant sysinfo::IS_SUPPORTED_SYSTEM">IS_<wbr>SUPPORTED_<wbr>SYSTEM</a></dt><dd>Returns <code>true</code> if this OS is supported. Please refer to the
+<a href="index.html">crate-level documentation</a> to get the list of supported OSes.</dd><dt><a class="constant" href="constant.MINIMUM_CPU_UPDATE_INTERVAL.html" title="constant sysinfo::MINIMUM_CPU_UPDATE_INTERVAL">MINIMUM_<wbr>CPU_<wbr>UPDATE_<wbr>INTERVAL</a></dt><dd>This is the minimum interval time used internally by <code>sysinfo</code> to refresh the CPU time.</dd><dt><a class="constant" href="constant.SUPPORTED_SIGNALS.html" title="constant sysinfo::SUPPORTED_SIGNALS">SUPPORTED_<wbr>SIGNALS</a></dt><dd>Returns the list of the supported signals on this system (used by
+<a href="struct.Process.html#method.kill_with" title="method sysinfo::Process::kill_with"><code>Process::kill_with</code></a>).</dd></dl><h2 id="functions" class="section-header">Functions<a href="#functions" class="anchor">§</a></h2><dl class="item-table"><dt><a class="fn" href="fn.get_current_pid.html" title="fn sysinfo::get_current_pid">get_<wbr>current_<wbr>pid</a></dt><dd>Returns the pid for the current process.</dd><dt><a class="fn" href="fn.set_open_files_limit.html" title="fn sysinfo::set_open_files_limit">set_<wbr>open_<wbr>files_<wbr>limit</a></dt><dd>This function is only used on Linux targets, when the <code>system</code> feature is enabled. In other
+cases, it does nothing and returns <code>false</code>.</dd></dl></section></div></main></body></html>


### PR DESCRIPTION
- Sysinfo is integrated to obtain real hardware and operating system data.
- The `info` command now displays: system name, kernel, OS version, hostname, memory, CPU, disks, and network.
- Clippy ambiguities and warnings have been removed.
- Structure ready for future extensions and plugins.